### PR TITLE
Change MemorySize to 3000 due deployment error

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -16,7 +16,7 @@ Resources:
       Handler: app.handler
       Runtime: nodejs12.x
       Timeout: 15
-      MemorySize: 4096
+      MemorySize: 3000
       Layers:
         - !Sub 'arn:aws:lambda:${AWS::Region}:764866452798:layer:chrome-aws-lambda:22'
       Environment:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated MemorySize parameter value to 3000 due to deployment error which appears for SnapshotFunction:

"Resource handler returned message: "'MemorySize' value failed to satisfy constraint: Member must have value less than or equal to 3008 (Service: Lambda, Status Code: 400, Request ID: xxxx- xxxxx)" 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
